### PR TITLE
Add information on contributing to BPM to ponymotes.net

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -128,7 +128,7 @@
 
   <h3>Contributing</h3>
   <p>BetterPonymotes is free and open source software distributed under the
-    <a href="http://www.gnu.org/licenses/agpl.html">GNU Affero General Public
+    <a href="https://www.gnu.org/licenses/agpl.html">GNU Affero General Public
     License</a>. The source code is
     <a href="https://github.com/Rothera/bpm">available on GitHub</a>; pull
     requests are welcome!</p>

--- a/web/index.html
+++ b/web/index.html
@@ -131,7 +131,7 @@
     <a href="https://www.gnu.org/licenses/agpl.html">GNU Affero General Public
     License</a>. The source code is
     <a href="https://github.com/Rothera/bpm">available on GitHub</a>; pull
-    requests are welcome!</p>
+    requests are welcome.</p>
 
   <h3>Supported Subreddits</h3>
   <p>BetterPonymotes gets its emotes from the following subreddits. If yours

--- a/web/index.html
+++ b/web/index.html
@@ -126,6 +126,13 @@
     else should be directed to <a href="https://www.reddit.com/r/betterponymotes">the
     subreddit</a>.</p>
 
+  <h3>Contributing</h3>
+  <p>BetterPonymotes is free and open source software distributed under the
+    <a href="http://www.gnu.org/licenses/agpl.html">GNU Affero General Public
+    License</a>. The source code is
+    <a href="https://github.com/Rothera/bpm">available on GitHub</a>; pull
+    requests are welcome!</p>
+
   <h3>Supported Subreddits</h3>
   <p>BetterPonymotes gets its emotes from the following subreddits. If yours
     isn't on this list, and you'd like it to be, make a request on


### PR DESCRIPTION
[](//bpm/ajhappy)  [As I mentioned before](https://www.reddit.com/r/betterponymotes/comments/3tdlx1/could_the_convert_emotes_outside_of_reddit_option/cxsjfd4), I think making the fact that BPM is open source a bit more visible might be helpful in attracting more developers to the project. Here's a quick and easy way to do that.