### PR TITLE
Remove unused entries in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 /animotes/*.gif
 
 /www/index.html
-/www/changelog.html
-/www/chrome-update.html
 /www/*-logo.png
 /www/betterponymotes.update.rdf
 


### PR DESCRIPTION
While going through the README, I noticed a couple entries in `.gitignore` entries for files that seem to have been removed a while ago...