### PR TITLE
Update build process for Firefox to use `jpm`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__
 /venv*
 /betterponymotes.pem
 /checktags-variants.log
+/node_modules

--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,14 @@ ADDON_DATA = \
     addon/bootstrap.css addon/options.html addon/options.css addon/options.js \
     addon/pref-setup.js
 
+.PHONY: default
 default: build/betterponymotes.xpi build/chrome.zip build/BPM.safariextension.zip build/export.json.bz2
 
+.PHONY: clean
 clean:
 	rm -fr build
 
+.PHONY: www
 www: web/* build/betterponymotes-*.mozsucks-*.xpi build/betterponymotes.update.rdf
 	cp web/firefox-logo.png www
 	cp web/chrome-logo.png www
@@ -64,6 +67,7 @@ www: web/* build/betterponymotes-*.mozsucks-*.xpi build/betterponymotes.update.r
 	cp build/betterponymotes-*.mozsucks-*.xpi www/betterponymotes.xpi
 	cp build/betterponymotes-*.mozsucks-*.xpi www/betterponymotes_$(VERSION).xpi
 
+.PHONY: sync
 sync:
 	rsync -e "ssh -p 40719" -zvLr --delete animotes/ lyra@ponymotes.net:/var/www/ponymotes.net/animotes
 	rsync -e "ssh -p 40719" -zvLr --delete www/ lyra@ponymotes.net:/var/www/ponymotes.net/bpm

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ADDON_DATA = \
     addon/bootstrap.css addon/options.html addon/options.css addon/options.js \
     addon/pref-setup.js
 
-default: build/betterponymotes.xpi build/chrome.zip build/BPM.safariextension build/export.json.bz2
+default: build/betterponymotes.xpi build/chrome.zip build/BPM.safariextension.zip build/export.json.bz2
 
 clean:
 	rm -fr build
@@ -141,7 +141,7 @@ build/chrome.zip: $(ADDON_DATA) addon/cr-background.html addon/cr-background.js
 	# Uncompressed due to prior difficulties with the webstore
 	cd build/chrome && zip -0 ../chrome.zip *
 
-build/BPM.safariextension: $(ADDON_DATA) addon/sf-Settings.plist addon/sf-background.html addon/sf-background.js
+build/BPM.safariextension.zip: $(ADDON_DATA) addon/sf-Settings.plist addon/sf-background.html addon/sf-background.js
 	mkdir -p build/BPM.safariextension
 
 	sed "s/\/\*{{version}}\*\//$(VERSION)/" < addon/sf-Info.plist > build/BPM.safariextension/Info.plist

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ You'll also need the following tools:
   need Python 2 installed and on your PATH with the name `python2` in order to
   tag emotes in BPM. (Many Linux distributions already have this by default.)
 
+- `pip`, the package manager that comes bundled with newer versions of Python.
+  Needed to install `virtualenv` and several Python packages for BPM's build
+  tools. Once `virtualenv` is installed and activated, the version of `pip`
+  created by `virtualenv` will be used, not the globally installed one.
+
+- `virtualenv`, a tool to create isolated Python environments. Used to create an
+  isolated environment for `pip` to install dependencies into
+
 - `zip`, a command line utility for creating zip-formatted archives. Needs to be
   on your PATH. If you don't already have it, it can probably be installed using
   your system's package manager. (E.g. `sudo apt-get install zip` on Ubuntu)

--- a/README.md
+++ b/README.md
@@ -52,17 +52,12 @@ You'll also need the following tools:
 - `virtualenv`, a tool to create isolated Python environments. Used to create an
   isolated environment for `pip` to install dependencies into
 
+- Node.js, used to install `jpm`, a tool for developing and packaging Firefox
+  add-ons
+
 - `zip`, a command line utility for creating zip-formatted archives. Needs to be
   on your PATH. If you don't already have it, it can probably be installed using
   your system's package manager. (E.g. `sudo apt-get install zip` on Ubuntu)
-
-- The Firefox Addon SDK. It comes in a zip file with a `bin/activate` shell
-  script. Source it to add its `bin/` to your `$PATH`, because you need the
-  `cfx` tool.
-
-- `uhura`. It's a little perl script used to sign the Firefox XPI's. It needs
-  to be on $PATH. I'm not sure exactly where I got it, and installing it is
-  a pain, since it depends on some CPAN modules. I forget which.
 
 - `apng2gif`. A tool to convert APNG files to GIF format. Needs to be on your
   PATH in order to build BPM.
@@ -276,7 +271,7 @@ This process is heavily controlled by `data/rules.yaml`, which lists:
   individual emote.
 - Explicit matchups for +v emotes that the code can't autodetect.
 
-The version number is at the top of the Makefile, and is used by `make` to
+The version number is defined in `package.json`, and is used by `make` to
 automatically update the version numbers every browser addon that BPM supports.
 
 When everything is updated, running `make` is sufficient to rebuild all packages.

--- a/addon/bpm-browser.js
+++ b/addon/bpm-browser.js
@@ -113,7 +113,7 @@ case "firefox-ext":
         // backend for the prefix (not wanting to do that is the reason for
         // hardcoding it). Ideally self.data.url() would be accessible to
         // content scripts, but it's not...
-        return "resource://jid1-thrhdjxskvsicw-at-jetpack/betterponymotes/data" + filename;
+        return "resource://jid1-thrhdjxskvsicw-at-jetpack/data" + filename;
     };
 
     make_css_link = function(filename, callback) {

--- a/addon/fx-jpmignore
+++ b/addon/fx-jpmignore
@@ -1,0 +1,1 @@
+jid1-tHrhDJXsKvsiCw@jetpack-*.update.rdf

--- a/addon/fx-main.js
+++ b/addon/fx-main.js
@@ -43,8 +43,8 @@ try {
     console.error(e.trace);
 }
 
-var manage_prefs = require("pref-setup").manage_prefs;
-var bpm_data = require("bpm-resources");
+var manage_prefs = require("./pref-setup").manage_prefs;
+var bpm_data = require("./bpm-resources");
 
 var storage = simple_storage.storage;
 

--- a/addon/fx-package.json
+++ b/addon/fx-package.json
@@ -1,10 +1,11 @@
 {
     "author": "Typhos",
     "description": "View Reddit ponymotes across the site",
-    "fullName": "BetterPonymotes",
-    "id": "jid1-tHrhDJXsKvsiCw",
+    "title": "BetterPonymotes",
+    "id": "jid1-tHrhDJXsKvsiCw@jetpack",
     "license": "AGPL v3",
     "name": "betterponymotes",
+    "main": "lib/main.js",
     "permissions": {"private-browsing": true},
     "preferences": [
         {
@@ -14,5 +15,11 @@
             "type": "control"
         }
     ],
-    "version": "/*{{version}}*/.mozsucks"
+    "version": "/*{{version}}*/",
+    "engines": {
+      "firefox": ">=38.0a1",
+      "fennec": ">=38.0a1"
+    },
+    "updateURL": "https://ponymotes.net/bpm/betterponymotes.update.rdf",
+    "updateLink": "https://ponymotes.net/bpm/betterponymotes_/*{{version}}*/.xpi"
 }

--- a/mungexpi.py
+++ b/mungexpi.py
@@ -25,21 +25,11 @@ import zipfile
 
 import lxml.etree
 
-XpiKey = """
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCZnk8XNNC6+pmDqxY/5CzREJXj
-BUY2JzvtcIMBH9gvyq7ZoOdCHIxm2rew7jZ76zdJfKlsUXI2tEdvR5C5PI4NBCw7
-PGm6yzGLSn8/cG7tG9XvpnyxGAX8TfQyV602NhAucqJXYGvCNePalZGU7FJbeJc1
-5JjoU+fv8mFBK/QTAwIDAQAB
-"""
-
 def make_rdf_element(tag, text=None):
     e = lxml.etree.Element("{http://www.mozilla.org/2004/em-rdf#}" + tag)
     if text:
         e.text = text
     return e
-
-def inject_update_key(manifest):
-    manifest[0].append(make_rdf_element("updateKey", XpiKey))
 
 def inject_seamonkey_target(manifest):
     target_app_tag = make_rdf_element("targetApplication")
@@ -66,7 +56,6 @@ def munge_install_rdf(input_filename, output_filename):
             item = "install.rdf"
 
             manifest = lxml.etree.fromstring(data)
-            inject_update_key(manifest)
             inject_seamonkey_target(manifest)
             data = lxml.etree.tostring(manifest, encoding=str, pretty_print=True)
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "betterponymotes",
+  "version": "66.238.0",
+  "description": "View Reddit ponymotes across the site",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Rothera/bpm.git"
+  },
+  "keywords": [
+    "emotes",
+    "ponymotes",
+    "pony",
+    "ponies",
+    "friendship"
+  ],
+  "author": "Typhos",
+  "license": "AGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/Rothera/bpm/issues"
+  },
+  "homepage": "https://github.com/Rothera/bpm#readme",
+  "devDependencies": {
+    "jpm": "^1.0.4"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+lxml


### PR DESCRIPTION
Updates the build process for Firefox to use `jpm` instead of the deprecated
`cfx` tool.

As part of this update, the following related changes were made:

1. Node.js is now required as part of the build process instead of the
   Firefox Addon SDK. Node is used to install `jpm`.
2. Firefox update manifests are no longer signed, and the build requirement
   for `uhura` has been dropped. Note that update manifests are not required
   to be signed as long as they are hosted at an HTTPS URL, [according to
   MDN][1].
3. BPM on all browsers now uses x.x.x format for its version numbers to
   comply with [SemVer][2], as required by `jpm`. (Note that technically
   Safari [also requires a similar format][3], but doesn't support full
   SemVer.)
4. The version number in the Makefile is now read from the `package.json`
   file in the root of the project.

Dependant on #8 because I needed those changes to get the build working for me, and #3, because this PR updates the README.

[1]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/jpm#Supporting_updates_for_self-hosted_add-ons
[2]: http://semver.org/
[3]: https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364