### PR TITLE
Center flag

### DIFF
--- a/addon/bpm-searchbox.js
+++ b/addon/bpm-searchbox.js
@@ -146,6 +146,7 @@ function inject_search_box() {
                        '<th class="bpflagtable-031e"><center><a style="color:black" class="bpm-emote bpmote-txt_excl bpflag-impact_excl_">yay.</a></center><br><center><code>-impact!</code></center></th>',
                        '<th class="bpflagtable-031e"><center><a style="color:black" class="bpm-emote bpmote-txt_excl bpflag-tahoma_excl_">yay.</a></center><br><center><code>-tahoma!</code></center></th>',
                        '<th class="bpflagtable-031e"><center><a style="color:black" class="bpm-emote bpmote-txt_excl bpflag-papyrus_excl_">yay.</a></center><br><center><code>-papyrus!</code></center></th>',
+                       '<th class="bpflagtable-031e"><center><a style="color:black" class="bpm-emote bpmote-txt_excl bpflag-center">yay.</a></center><br><center><code>-center</code></center></th>',
                        '</tr>',
                    '</table></center><br>',
                    '<br><a class="bpm-emote bpflag-spin bpflag-s1 bpmote-zecora"></a><p class="bpm-sb-flag">Intensity and speed modifiers allow you to modify how flags work and appear. For example, <code class="bpm-sb-noconvert-zecora"></code> would make the emote spin very fast (see left).<br>The examples below demonstrate the least and most intense of the modification flags.</p>',

--- a/addon/bpmotes.css
+++ b/addon/bpmotes.css
@@ -630,7 +630,6 @@ word-break:normal;}
 /*==center==*/
 
 .bpflag-center {
-    height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/addon/bpmotes.css
+++ b/addon/bpmotes.css
@@ -626,3 +626,12 @@ word-break:normal;}
    filter: grayscale(1)!important;
    -webkit-filter: grayscale(1)!important;
 }
+
+/*==center==*/
+
+.bpflag-center {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}


### PR DESCRIPTION
Adds the `-center` flag (and all documentation to go with it) to center text wrapped in `[](/txt!)`. If used on a normal emote, nothing happens.

Use case of `-center`:
<img width="957" alt="use case" src="https://cloud.githubusercontent.com/assets/10801851/16548078/ba5be698-4150-11e6-9209-1580f89c840a.png">

[The above post is located here.](https://www.reddit.com/r/illumineighti/comments/4mb2bz/mmm_rpcmasterrace_is_shadowbanning_secret/d4y1mvs)
