### PR TITLE
Bug fixes with alt-text

### DIFF
--- a/addon/bpm-alttext.js
+++ b/addon/bpm-alttext.js
@@ -15,6 +15,8 @@ var spoiler_links = [
     "/a",       // r/ShingekiNoKyojin
     "/m",       // r/ShingekiNoKyojin
     "/t",       // r/ShingekiNoKyojin
+    "#spoiler", // r/gravityfalls
+    "#fg",      // r/LearnJapanese
     ];
 
 /*


### PR DESCRIPTION
Fixes a bug in which /r/LearnJapanese's furigana would be duplicated in the alt-text. Also added in #spoiler because that wasn't there for some reason.

Tested and works as intended.

[See here for context.](https://www.reddit.com/r/betterponymotes/comments/4v8150/request_blacklist_furigana_alttext_in/)