### PR TITLE
[Bugfix] Chaos/extracss flags don't show up in Firefox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ build/betterponymotes.xpi: $(ADDON_DATA) addon/fx-main.js addon/fx-install.rdf
 	cp addon/bpmotes.css build/firefox/data
 	cp addon/combiners-nsfw.css build/firefox/data
 	cp addon/extracss-pure.css build/firefox/data
+	cp addon/extracss-webkit.css build/firefox/data
 	cp addon/options.css build/firefox/data
 	cp addon/options.html build/firefox/data
 	cp addon/options.js build/firefox/data


### PR DESCRIPTION
This PR fixes a bug that caused emote flags to not work in certain builds of Firefox. This is done by adding the WebKit stylesheet into the Firefox versions of BPM. Tested on the Developer builds of Firefox with the latest version of BPM.

Special thanks to /u/Rene_Z for discovering the cause of the bug, and /u/doodwhatsrsly for reporting it.
