### PR TITLE
[Enhancement] Add tag aliases

### DIFF
--- a/data/tags.yaml
+++ b/data/tags.yaml
@@ -41,10 +41,10 @@ HiddenTags:
 - +drop
 
 TagAliases:
-  +applejack: [+aj]
+  +applejack: [+aj, +applepone, +applehorse]
   +fluttershy: [+fs]
-  +pinkiepie: [+pp]
-  +rainbowdash: [+rbd, +rd]
+  +pinkiepie: [+pp, +ponk]
+  +rainbowdash: [+rbd, +rd, +dashie]
   +twilightsparkle: [+ts]
 
   +applebloom: [+ab]

--- a/data/tags.yaml
+++ b/data/tags.yaml
@@ -78,12 +78,12 @@ TagImplications:
   +broken: [+remove]
 
   # Mane 6
-  +applejack: [+canon, +mane, +pony]
-  +fluttershy: [+canon, +mane, +pony]
-  +pinkiepie: [+canon, +mane, +pony]
+  +applejack: [+canon, +main, +mane, +pony]
+  +fluttershy: [+canon, +main, +mane, +pony]
+  +pinkiepie: [+canon, +main, +mane, +pony]
   +rarity: [+canon, +mane, +pony]
-  +rainbowdash: [+canon, +mane, +pony]
-  +twilightsparkle: [+canon, +mane, +pony]
+  +rainbowdash: [+canon, +main, +mane, +pony]
+  +twilightsparkle: [+canon, +main, +mane, +pony]
 
   # CMC
   +applebloom: [+canon, +cmc, +major, +pony]


### PR DESCRIPTION
This PR is a minor one that adds more aliases for the Mane 6, and are as followed:
### Mane 6 (all together):

+main (for those who avoid horse puns)
### Individual Ponies:

+ponk (Pinkie Pie, it’s a MLPLounge thing)

+dashie (Rainbow Dash, nickname from a certain fanfic)

+applepone (slang for Applejack)

+applehorse (slang for Applejack again)

This is more of a quality-of-life addition (if you can even call it that) that can or can not be merged; I don’t care either way. It took more time typing out this description than I did adding the tags. :P
