### PR TITLE
Allow the "custom emote" field to support emotes with the [](#emote) format

### DIFF
--- a/addon/bpm-post.js
+++ b/addon/bpm-post.js
@@ -148,7 +148,7 @@ function process_element(store, element, convert_unknown) {
     // attribute: the former is mangled by the browser, which we don't want.
     var href = element.getAttribute("href");
 
-    if(href && href[0] === "/") {
+    if(href && href[0] === "/" || href[0] === "#") {
         // Don't normalize case for emote lookup- they are case sensitive
         var parts = href.split("-");
         var name = parts[0];

--- a/addon/pref-setup.js
+++ b/addon/pref-setup.js
@@ -92,8 +92,8 @@ function sanitize_emote(s) {
 }
 
 //                  a    :suffix          [href |   ="( /emote name )"] :suffix         (through '}')
-var block_regexp = /a\s*(:[a-zA-Z\-()]+)?\[href[|^]?="(\/[\w:!#\/]+)"\](:[a-zA-Z\-()]+)?[^}]*}/g;
-var emote_regexp = /a\s*(:[a-zA-Z\-()]+)?\[href[|^]?="(\/[\w:!#\/]+)"\](:[a-zA-Z\-()]+)?/;
+var block_regexp = /a\s*(:[a-zA-Z\-()]+)?\[href[|^]?="(((\#)|(\/))[\w:!#\/]+)"\](:[a-zA-Z\-()]+)?[^}]*}/g; // CSS stylesheet?
+var emote_regexp = /a\s*(:[a-zA-Z\-()]+)?\[href[|^]?="([\w:!#\/]+)"\](:[a-zA-Z\-()]+)?/; // Emote strucutre?
 
 function strip_subreddit_css(data) {
     // Strip comments


### PR DESCRIPTION
This PR adds experimental support for emotes from subreddits like /r/gravityfalls to be added in as a custom subreddit. It adds the following:

- Supports subreddits in the `[](#emote)` format

    - `[](#emote)` emotes aren’t converted by default (to allow for people to use alttext without an emote visible)

This Pull Request has the following known bugs:

- `[](#emote)` emotes don’t support global emote conversion, as it’s too buggy at the moment io include (fixing the regex has the issue of the hash/slash of the emote being visible as alt-text)

- Doesn’t support /r/StevenUniverse’s `[](#su-emote)` format (because of the dash).

- Doesn’t support /r/Frozen’s trash emote CSS (that I don’t plan to support because it’s so strange)

The following is untested at the moment:

- How this functions if an emote formatted as `[](#emote)` is added in as a “core” emote (bundled with BPM).

I will try to fix most of the bugs over time, how long that will take. Feel free to wait to merge until this fork is mature enough.