### PR TITLE
Enable multiprocess support

### DIFF
--- a/addon/fx-package.json
+++ b/addon/fx-package.json
@@ -5,7 +5,7 @@
     "id": "jid1-tHrhDJXsKvsiCw@jetpack",
     "license": "AGPL v3",
     "name": "betterponymotes",
-    "permissions": {"private-browsing": true},
+    "permissions": {"private-browsing": true,"multiprocess": true},
     "preferences": [
         {
             "label": "Preferences",


### PR DESCRIPTION
This PR will allow BPM to support multiprocess support. BPM already was ready for such support, but this PR disables the shims (see [here](https://developer.mozilla.org/en-US/Add-ons/SDK/Guides/Multiprocess_Firefox_and_the_SDK) and formally declares multiprocess support in the permissions.

Compatibility was extensively tested, and this is a list of features that work perfectly fine:
- Emote selection menu (globally and in Reddit)
- Emote rendering
- Custom emotes
- Global emotes
- Emote hiding / click blocker
- All flags (Fully working, also used #26 during testing)
- Alt-text revealing

Everything was tested under Firefox Nightly 52.0a1 (2016-10-17) (64-bit) using BetterPonymotes (Latest version, plus Pull Requests #26, #30, and the permissions modified to force-enable e10) on macOS Sierra 10.12. 

**tl;dr: Fixes the issue reported [here](https://www.reddit.com/r/betterponymotes/comments/57svk8/featureupdate_request_support_for_electrolysis_on/).**
