### PR TITLE
add emotes button in new modmail

### DIFF
--- a/addon/bpm-header.js
+++ b/addon/bpm-header.js
@@ -56,8 +56,11 @@ var DOMAIN_BLACKLIST = [
 // Used to determine which domain BPM is running on.
 // This affects button injection and some css classes.
 var is_reddit = false;
+var is_modreddit = false;
 var is_voat = false;
-if (ends_with(document.location.hostname, "reddit.com")) {
+if (ends_with(document.location.hostname, "mod.reddit.com")) {
+    is_modreddit = true;
+} else if (ends_with(document.location.hostname, "reddit.com")) {
     is_reddit = true;
 } else if (ends_with(document.location.hostname, "voat.co")) {
     is_voat = true;

--- a/addon/bpm-main.js
+++ b/addon/bpm-main.js
@@ -108,7 +108,7 @@ function init_css(store) {
 function main() {
     log_info("Starting up");
     setup_browser({"prefs": 1, "customcss": 1}, function(store) {
-        if(document.location && document.location.hostname && (is_reddit || is_voat)) {
+        if(document.location && document.location.hostname && (is_reddit || is_modreddit || is_voat)) {
             reddit_main(store);
         } else {
             global_main(store);

--- a/addon/bpm-reddit.js
+++ b/addon/bpm-reddit.js
@@ -130,6 +130,8 @@ function run_reddit(store, expand_emotes) {
     init_search_box(store);
     if (is_reddit) {
         var usertext_edits = slice(document.getElementsByClassName("usertext-edit"));
+    } else if (is_modreddit) {
+        var usertext_edits = slice(document.getElementsByClassName("ThreadViewer__replyContainer"));
     } else if (is_voat) {
         var usertext_edits = slice(document.getElementsByClassName("markdownEditor"));
     }
@@ -180,6 +182,8 @@ function run_reddit(store, expand_emotes) {
             // TODO: move up in case we're inside it?
             if (is_reddit) {
                 var usertext_edits = slice(root.getElementsByClassName("usertext-edit"));
+            } else if (is_modreddit) {
+                var usertext_edits = slice(root.getElementsByClassName("ThreadViewer__replyContainer"));
             } else if (is_voat) {
                 var usertext_edits = slice(root.getElementsByClassName("markdownEditor"));
             }

--- a/addon/bpm-reddit.js
+++ b/addon/bpm-reddit.js
@@ -131,7 +131,11 @@ function run_reddit(store, expand_emotes) {
     if (is_reddit) {
         var usertext_edits = slice(document.getElementsByClassName("usertext-edit"));
     } else if (is_modreddit) {
-        var usertext_edits = slice(document.getElementsByClassName("ThreadViewer__replyContainer"));
+        if (ends_with(document.location.pathname, "create")) {
+            var usertext_edits = slice(document.getElementsByClassName("NewThread__form"));
+        } else {
+            var usertext_edits = slice(document.getElementsByClassName("ThreadViewer__replyContainer"));
+        }
     } else if (is_voat) {
         var usertext_edits = slice(document.getElementsByClassName("markdownEditor"));
     }
@@ -183,7 +187,11 @@ function run_reddit(store, expand_emotes) {
             if (is_reddit) {
                 var usertext_edits = slice(root.getElementsByClassName("usertext-edit"));
             } else if (is_modreddit) {
-                var usertext_edits = slice(root.getElementsByClassName("ThreadViewer__replyContainer"));
+                if (ends_with(document.location.pathname, "create")) {
+                    var usertext_edits = slice(root.getElementsByClassName("NewThread__form"));
+                } else {
+                    var usertext_edits = slice(root.getElementsByClassName("ThreadViewer__replyContainer"));
+                }
             } else if (is_voat) {
                 var usertext_edits = slice(root.getElementsByClassName("markdownEditor"));
             }

--- a/addon/bpm-searchbox.js
+++ b/addon/bpm-searchbox.js
@@ -584,6 +584,9 @@ function inject_emotes_button(store, usertext_edits) {
             if(is_compact) {
                 // Blend in with the other mobile buttons
                 button.classList.add("newbutton");
+            } else if(is_modreddit) {
+                // Blend in with the other modmail buttons
+                button.classList.add("Button");
             } else if(is_voat) {
                 button.classList.add("markdownEditorImgButton");
                 button.classList.add("bpm-voat");
@@ -601,6 +604,7 @@ function inject_emotes_button(store, usertext_edits) {
             // way to the right, next to the "formatting help" link. However,
             // this breaks rather badly on .compact display (sort of merging
             // into it), so do something different there.
+            // If in modmail, have it on the left instead.
             // If on voat, do something completely different.
             if (is_reddit) {
                 if(is_compact) {
@@ -610,6 +614,9 @@ function inject_emotes_button(store, usertext_edits) {
                     var bottom_area = find_class(usertext_edits[i], "bottom-area");
                     bottom_area.insertBefore(button, bottom_area.firstChild);
                 }
+            } else if (is_modreddit) {
+                var button_bar = find_class(usertext_edits[i], "ThreadViewerReplyForm__replyFooter");
+                button_bar.insertBefore(button, find_class(button_bar, "ThreadViewerReplyForm__formattingHelp"));
             } else if (is_voat) {
                 var editbar = find_class(usertext_edits[i], "markdownEditorMainMenu");
                 editbar.appendChild(button);

--- a/addon/bpm-searchbox.js
+++ b/addon/bpm-searchbox.js
@@ -615,8 +615,13 @@ function inject_emotes_button(store, usertext_edits) {
                     bottom_area.insertBefore(button, bottom_area.firstChild);
                 }
             } else if (is_modreddit) {
-                var button_bar = find_class(usertext_edits[i], "ThreadViewerReplyForm__replyFooter");
-                button_bar.insertBefore(button, find_class(button_bar, "ThreadViewerReplyForm__formattingHelp"));
+                if (ends_with(document.location.pathname, "create")) {
+                    var button_bar = find_class(usertext_edits[i], "NewThread__submitRow");
+                    button_bar.insertBefore(button, find_class(button_bar, "NewThread__formattingHelp"));
+                } else {
+                    var button_bar = find_class(usertext_edits[i], "ThreadViewerReplyForm__replyFooter");
+                    button_bar.insertBefore(button, find_class(button_bar, "ThreadViewerReplyForm__formattingHelp"));
+                }
             } else if (is_voat) {
                 var editbar = find_class(usertext_edits[i], "markdownEditorMainMenu");
                 editbar.appendChild(button);

--- a/addon/bpmotes.css
+++ b/addon/bpmotes.css
@@ -140,6 +140,15 @@
     margin: 2px !important;
 }
 
+/*
+ * Emotes button on mod.reddit.com. Float left because new modmail
+ * has the button on the other side of the textfield.
+ */
+.bpm-search-toggle.Button {
+    margin: 0 12px 0 0 !important;
+    float: left;
+}
+
 /* Emotes button on Voat. */
 .bpm-search-toggle.bpm-voat {
     margin-left: 1px;


### PR DESCRIPTION
BPM looks to be working in the [new modmail](https://www.reddit.com/r/modmailbeta/), only the `emotes` button does not show under textareas because of its new layout, classes, etc. This PR adds the button back similar to how it was added for Voat. Tested on the latest Firefox and Chrome.