### PR TITLE
Re-tag /sunseteyebrow with the correct character name

### DIFF
--- a/tags/sunsetshimmer.json
+++ b/tags/sunsetshimmer.json
@@ -300,7 +300,7 @@
 "/sunsetdress": ["+sunsetshimmer"],
 "/sunsetexcited": ["+sunsetshimmer"],
 "/sunsetexplains": ["+v"],
-"/sunseteyebrow": ["+starlightglimmer"],
+"/sunseteyebrow": ["+sunsetshimmer"],
 "/sunsetfacehoof": ["+v"],
 "/sunsetfailure": ["+equestriagirls", "+sunsetshimmer"],
 "/sunsetgallop": ["+v"],


### PR DESCRIPTION
Right now /sunseteyebrow is in the +starlight list and it really grinds my gears.