### PR TITLE
Nessesary changes to /teapot's special CSS for it to work

### DIFF
--- a/addon/bpmotes.css
+++ b/addon/bpmotes.css
@@ -659,12 +659,11 @@ word-break:normal;}
     justify-content: center;
 }
 
-a[href|="/teapot"]:hover + .bpm-emote {
+.bpmote-teapot:hover + .bpm-emote {
     width: 70px !important;
     height: 70px !important;
-    background-image: url("//b.thumbs.redditmedia.com/xPK94sOv-Nd3SG_qc6ef2juI6-xYnhlPi8nhDDXCzwo.png") !important;
+    background-image: url("https://b.thumbs.redditmedia.com/GwhwUuRNzvh9kzxDqoBTmY_WbMAZh_K2wj_HoqCfW5g.png") !important;
     display: block;
     clear: none;
-    float: left;
-    background-position: -350px -0px !important;
+    background-position: 0px 0px !important;
 }


### PR DESCRIPTION
First of all, outside of reddit emotes are `span` and not `a`. Now the selector should just look for `.bpmote-teapot` class which /teapot emote should have no matter what it is.
Second of all `//b.thumbs.redditmedia.com/xPK94sOv-Nd3SG_qc6ef2juI6-xYnhlPi8nhDDXCzwo.png` link did not appear to work for me in Firefox and Chromium without `https://`, so I thought I might as well move the teacup sprite into it's own separate spritesheet and have the link hardcoded permamently. If that's okay, that is. If it's not I'm open for any alternatives.