### PR TITLE
Port to WebExtensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ADDON_DATA = \
     addon/bootstrap.css addon/options.html addon/options.css addon/options.js \
     addon/pref-setup.js
 
-default: build/betterponymotes.xpi build/chrome.zip build/BPM.safariextension build/export.json.bz2
+default: build/betterponymotes.xpi build/chrome.zip build/firefox.zip build/BPM.safariextension build/export.json.bz2
 
 clean:
 	rm -fr build
@@ -135,6 +135,32 @@ build/chrome.zip: $(ADDON_DATA) addon/cr-background.html addon/cr-background.js
 	cp betterponymotes.pem build/chrome/key.pem
 	# Uncompressed due to prior difficulties with the webstore
 	cd build/chrome && zip -0 ../chrome.zip *
+
+build/firefox.zip: $(ADDON_DATA) addon/cr-background.html addon/cr-background.js
+	mkdir -p build/firefox_webextension
+
+	sed "s/\/\*{{version}}\*\//$(VERSION)/" < addon/fx-manifest.json > build/firefox_webextension/manifest.json
+
+	cp addon/cr-background.html build/firefox_webextension/background.html
+	cp addon/cr-background.js build/firefox_webextension/background.js
+
+	cp build/betterponymotes.js build/firefox_webextension
+	cp build/bpm-resources.js build/firefox_webextension
+	cp build/emote-classes.css build/firefox_webextension
+
+	cp addon/bootstrap.css build/firefox_webextension
+	cp addon/bpmotes.css build/firefox_webextension
+	cp addon/combiners-nsfw.css build/firefox_webextension
+	cp addon/extracss-pure.css build/firefox_webextension
+	cp addon/extracss-webkit.css build/firefox_webextension
+	cp addon/options.css build/firefox_webextension
+	cp addon/options.html build/firefox_webextension
+	cp addon/options.js build/firefox_webextension
+	cp addon/pref-setup.js build/firefox_webextension
+
+	cp betterponymotes.pem build/firefox_webextension/key.pem
+	# Uncompressed due to prior difficulties with the webstore
+	cd build/firefox_webextension && zip -0 ../firefox_webextension.xpi *
 
 build/BPM.safariextension: $(ADDON_DATA) addon/sf-Settings.plist addon/sf-background.html addon/sf-background.js
 	mkdir -p build/BPM.safariextension

--- a/addon/bpm-browser.js
+++ b/addon/bpm-browser.js
@@ -149,7 +149,7 @@ case "chrome-ext":
         }
         data.method = method;
         log_debug("_send_message:", data);
-        chrome.extension.sendMessage(data, _message_handler);
+        chrome.runtime.sendMessage(data, _message_handler);
     };
 
     var _message_handler = catch_errors(function(message) {
@@ -175,7 +175,7 @@ case "chrome-ext":
     };
 
     linkify_options = function(element) {
-        element.href = chrome.extension.getURL("/options.html");
+        element.href = chrome.runtime.getURL("/options.html");
         element.target = "_blank";
     };
     break;

--- a/addon/cr-background.js
+++ b/addon/cr-background.js
@@ -54,7 +54,7 @@ var pref_manager = manage_prefs(sr_name2id, {
 });
 
 // Content script requests
-chrome.extension.onMessage.addListener(function(message, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
     switch(message.method) {
         case "get_initdata":
             var reply = {"method": "initdata"};

--- a/addon/fx-manifest.json
+++ b/addon/fx-manifest.json
@@ -1,0 +1,49 @@
+{
+    "background": {
+        "page": "background.html"
+    },
+    "content_scripts": [
+        {
+            "all_frames": true,
+            "js": [
+                "bpm-resources.js",
+                "betterponymotes.js"
+            ],
+            "matches": [
+                "*://*/*"
+            ],
+            "run_at": "document_start"
+        }
+    ],
+    "applications": {
+      "gecko": {
+        "id": "jid1-tHrhDJXsKvsiCw@jetpack"
+      }
+    },
+    "description": "View Reddit ponymotes across the site",
+    "homepage_url": "https://ponymotes.net/bpm/",
+    "manifest_version": 2,
+    "minimum_chrome_version": "20",
+    "name": "BetterPonymotes",
+    "options_ui": {
+        "page": "options.html",
+        "browser_style": true
+    },
+    "permissions": [
+        "http://*.reddit.com/",
+        "https://*.reddit.com/",
+        "http://*.redditstatic.com/",
+        "https://*.redditstatic.com/",
+        "http://*.redditmedia.com/",
+        "https://*.redditmedia.com/"
+    ],
+    "version": "/*{{version}}*/.mozsucks",
+    "web_accessible_resources": [
+        "bpmotes.css",
+        "emote-classes.css",
+        "combiners-nsfw.css",
+        "extracss-pure.css",
+        "extracss-webkit.css",
+        "options.html"
+    ]
+}

--- a/addon/options.js
+++ b/addon/options.js
@@ -46,7 +46,7 @@ var bpm_utils = {
     platform: (function() {
         if(self.on !== undefined) {
             return "firefox-ext";
-        } else if(_bpm_global("chrome") !== undefined && chrome.extension !== undefined) {
+        } else if(_bpm_global("chrome") !== undefined && chrome.runtime !== undefined) {
             return "chrome-ext";
         } else if(_bpm_global("safari")) {
             return "safari-ext";
@@ -130,7 +130,7 @@ case "chrome-ext":
                 data = {};
             }
             data["method"] = method;
-            chrome.extension.sendMessage(data, this._message_handler.bind(this));
+            chrome.runtime.sendMessage(data, this._message_handler.bind(this));
         },
 
         _message_handler: function(message) {


### PR DESCRIPTION
This should port BPM to WebExtensions. This doesn't change anything with the current Firefox addons, but provides additional support for WebExtensions (when built, it is named appropriately).

The file you want to submit to Mozilla is `build/firefox_webextension.xpi`. The `build/firefox_webextension` folder is the corresponding addon folder.

Everything in the below tests work in both Chrome Canary, Firefox Nightly, and Safari:

## Tested:

- Emote browser
    - Emote Insertion
    - Help Menus
    - Resizing/Moving
    - Escape-To-Close
    - Prevent Dragging Off Screen
- Animotes
- Collapse Emotes
- Effects
- ExtraCSS effects
- Preferences
- RES Support
    - Live Preview
    - Night Mode
    - Show In Front-Page Preview
- [Everything From This Thread](https://www.reddit.com/r/heyitsshugatest/comments/4hjrt5/bpm_bug_found_certain_modifiers_wont_work_in/) works
- `[](/spoiler)`
- Text Effects (`[Hello](/red!-center)` works as intended)

(This should also resolve #47, and also resolve #15 [because I updated the syntax needed for the manifest](https://github.com/Shugabuga/bpm/blob/f65797cbfa1bd19ebe158ee84ad66b93e0f4a5c4/addon/fx-manifest.json#L28-L31))

EDIT: Realized #15 was still closed