### PR TITLE
Ignore alt-text for .expando-button, to which RES may add a `title`

### DIFF
--- a/addon/bpm-alttext.js
+++ b/addon/bpm-alttext.js
@@ -75,7 +75,8 @@ function should_convert_alt_text(element, state, is_emote) {
     // Work around RES putting tag links and other things with alt-text on
     // them in the middle of posts- we don't want to expand those.
     if(element.classList.contains("userTagLink") ||
-       element.classList.contains("voteWeight")) {
+       element.classList.contains("voteWeight") ||
+       element.classList.contains("expando-button")) {
         return false;
     }
 


### PR DESCRIPTION
(`title` on .expando-button is not user-controlled, so this doesn't affect link title text)

Fixes #41.

Tested in Chrome 62 by applying the patch to 66.261 from the store; I haven't tried building from source.